### PR TITLE
docs: add a guided tour of the current crate

### DIFF
--- a/src/guide/README.md
+++ b/src/guide/README.md
@@ -1,16 +1,12 @@
-# Guide: tutorials for every audience
+# Guide
 
-The pages, each self-contained, each with code:
-
-* [Writing an application](crate::guide::applications) — hub, with
-  [the Communication Layer](crate::guide::applications::communication)
-  (the default) and
+* [Writing an application](crate::guide::applications) — overview, with
+  runnable Communication Layer role examples and examples that use
   [the Transport Layer](crate::guide::applications::transport) directly.
 * [Implementing a transport](crate::guide::utransport) — the
-  [`UTransport`] contract from the provider side.
-* [The trait map](crate::guide::trait_map) — how the traits fit together
-  and which ones are yours.
+  relationship between [`UTransport`](crate::UTransport), L1 requirements, and
+  protocol bindings, with links to published transport implementations.
+* [The trait map](crate::guide::trait_map) — how the public traits fit together.
 
-Not sure where you fit? If you're *using* uProtocol, start with
-[applications](crate::guide::applications); if a trait name brought you
-here, start with [the trait map](crate::guide::trait_map).
+Start with [applications](crate::guide::applications) to use uProtocol, or the
+[trait map](crate::guide::trait_map) for an API overview.

--- a/src/guide/README.md
+++ b/src/guide/README.md
@@ -1,0 +1,16 @@
+# Guide: tutorials for every audience
+
+The pages, each self-contained, each with code:
+
+* [Writing an application](crate::guide::applications) — hub, with
+  [the Communication Layer](crate::guide::applications::communication)
+  (the default) and
+  [the Transport Layer](crate::guide::applications::transport) directly.
+* [Implementing a transport](crate::guide::utransport) — the
+  [`UTransport`] contract from the provider side.
+* [The trait map](crate::guide::trait_map) — how the traits fit together
+  and which ones are yours.
+
+Not sure where you fit? If you're *using* uProtocol, start with
+[applications](crate::guide::applications); if a trait name brought you
+here, start with [the trait map](crate::guide::trait_map).

--- a/src/guide/applications.md
+++ b/src/guide/applications.md
@@ -74,10 +74,11 @@ transport such as
 [`up-transport-mqtt5`](https://crates.io/crates/up-transport-mqtt5), or
 [`up-transport-vsomeip`](https://crates.io/crates/up-transport-vsomeip).
 
-Publishers, notifiers, subscribers, RPC clients, and RPC servers can share one
-[`Arc`](std::sync::Arc) clone. The role implementations are generic over
-[`UTransport`](crate::UTransport), so application code does not need to name
-the concrete transport type:
+Publishers, notifiers, subscribers, RPC clients, and RPC servers can share the
+same [`UTransport`](crate::UTransport) instance through
+[`Arc`](std::sync::Arc) clones. The role implementations are generic over
+`UTransport`, so application code does not need to name the concrete transport
+type:
 
 ```rust
 # use std::sync::Arc;

--- a/src/guide/applications.md
+++ b/src/guide/applications.md
@@ -1,83 +1,122 @@
-# Writing an application
+# Build an application
 
-Applications talk uProtocol through one of **two layers**, and knowing
-which one you're on is the whole orientation:
+The application-facing APIs are:
 
 * **[The Communication Layer](crate::guide::applications::communication)**
-  (up-L2, feature `communication`) — role traits: `Publisher`,
-  `Subscriber`, `Notifier`, `RpcClient`, `RpcServer`. **This is the
-  recommended starting point.** Start here unless you have a reason not to.
-* **[The Transport Layer](crate::guide::applications::transport)**
-  (up-L1, no features) — build [`UMessage`](crate::UMessage)s yourself
-  and hand them to a [`UTransport`](crate::UTransport). The floor the
-  roles stand on; yours directly when you need minimal dependencies,
-  custom filtering, or direct control over message construction.
-
-Thirty seconds to first message, on the communication layer:
+  provides five role traits across four messaging patterns:
+  [`Publisher`](crate::communication::Publisher),
+  [`Subscriber`](crate::communication::Subscriber),
+  [`Notifier`](crate::communication::Notifier), and
+  [`RpcClient`](crate::communication::RpcClient) with
+  [`RpcServer`](crate::communication::RpcServer).
+* **[The Transport Layer](crate::guide::applications::transport)** provides
+  direct message-level control and is the interface implemented by transport
+  providers.
 
 ```rust
 use std::sync::Arc;
+use up_rust::communication::{CallOptions, PubSubError, Publisher, SimplePublisher, UPayload};
 use up_rust::local_transport::LocalTransport;
 use up_rust::{StaticUriProvider, UPayloadFormat};
-use up_rust::communication::{CallOptions, Publisher, SimplePublisher, UPayload};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), PubSubError> {
     let transport = Arc::new(LocalTransport::default());
-    let me = Arc::new(StaticUriProvider::new("my-vehicle", 0x1_0001, 1)?);
+    let identity = Arc::new(
+        StaticUriProvider::new("my-vehicle", 0x1_0001, 1)
+            .expect("valid publisher identity"),
+    );
 
-    SimplePublisher::new(transport, me)
-        .publish(0x8001, CallOptions::for_publish(None, None, None),
-                 Some(UPayload::new("92.5", UPayloadFormat::Text)))
+    SimplePublisher::new(transport, identity)
+        .publish(
+            0x8001,
+            CallOptions::for_publish(None, None, None),
+            Some(UPayload::new("92.5", UPayloadFormat::Text)),
+        )
         .await?;
-    // Delivered to every subscriber of my-vehicle/0x1_0001/1/0x8001.
     Ok(())
 }
 ```
 
-Everything below applies to both layers.
+## Choose an application role
 
-## Addresses in one box
+| Requirement | API | Additional dependency |
+| --- | --- | --- |
+| One-to-many events | [`Publisher`](crate::communication::Publisher) | — |
+| Receive published events | [`Subscriber`](crate::communication::Subscriber) | [`InMemorySubscriber`](crate::communication::InMemorySubscriber) uses uSubscription for bookkeeping and status |
+| One-way delivery to one uEntity | [`Notifier`](crate::communication::Notifier) | — |
+| Request/response | [`RpcClient`](crate::communication::RpcClient) and [`RpcServer`](crate::communication::RpcServer) | — |
+| Direct message send or receive | [`UTransport`](crate::UTransport) | — |
 
-Every example below uses [`UUri`](crate::UUri) literals; here is what
-they mean, once:
+## Address messages with UUri
+
+[`UUri`](crate::UUri) addresses identify an authority, uEntity, major version,
+and resource:
 
 ```text
 UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)
                       authority    entity   ver resource
 ```
 
-* **authority** — which device/domain the uEntity lives on.
-* **entity id** — which uEntity (a u32; deployments assign these).
-* **major version** — the uEntity's API major version.
-* **resource id** — *what* within the uEntity: `0x0000` is the uEntity
-  itself (the address RPC responses return to), ids `0x0001..=0x7FFF`
-  are RPC **methods**, and ids **`0x8000..=0xFFFE` are topics** a uEntity
-  publishes. `0xFFFF` is the wildcard. That is why the publish examples
-  use `0x8001` and the RPC endpoint uses `0x00A1`.
+* **authority** identifies the device or domain.
+* **entity id** identifies the uEntity.
+* **major version** identifies the uEntity API version.
+* **resource id** identifies a resource within the uEntity. `0x0000` addresses
+  the uEntity, `0x0001..=0x7FFF` identify RPC methods,
+  `0x8000..=0xFFFE` identify topics, and `0xFFFF` is the resource wildcard.
 
-## When things fail
+## Share a transport
 
-Every operation returns a code you can act on. Transport-level errors
-arrive as [`UStatus`](crate::UStatus) carrying a [`UCode`](crate::UCode):
-`Unavailable` (link down — retry with backoff), `AlreadyExists`
-(duplicate listener registration), `InvalidArgument` (a filter or
-message the transport cannot express), `PermissionDenied`. The roles
-wrap these: publishing fails with `PubSubError`, RPC with
-`ServiceInvocationError` — whose `CommStatus` variant means *the remote
-service* answered with a failure code, distinct from the transport
-failing to deliver. Timeouts surface as `CommStatus(DeadlineExceeded)`
-when the `ttl` you passed in `CallOptions` expires.
+The examples use [`LocalTransport`](crate::local_transport::LocalTransport), the
+crate's in-process push transport. A deployment can instead construct a
+transport such as
+[`up-transport-zenoh`](https://crates.io/crates/up-transport-zenoh),
+[`up-transport-mqtt5`](https://crates.io/crates/up-transport-mqtt5), or
+[`up-transport-vsomeip`](https://crates.io/crates/up-transport-vsomeip).
 
-## Where a real transport comes from
+Publishers, notifiers, subscribers, RPC clients, and RPC servers can share one
+[`Arc`](std::sync::Arc) clone. The role implementations are generic over
+[`UTransport`](crate::UTransport), so application code does not need to name
+the concrete transport type:
 
-The examples use `LocalTransport` so they can run anywhere. In a
-deployment, you construct one of the transport crates at startup —
-`up-transport-zenoh-rust`, `up-transport-mqtt5-rust`,
-`up-transport-vsomeip-rust`, and so on — configure it, wrap it in an
-`Arc`, and hand that same `Arc` to every role. Application code stays
-transport-agnostic: the role implementations are generic over
-`UTransport`, which is the point of the protocol.
+```rust
+# use std::sync::Arc;
+# use up_rust::local_transport::LocalTransport;
+let transport = Arc::new(LocalTransport::default());
+let publisher_transport = transport.clone();
+let rpc_transport = transport.clone();
+# let _ = (publisher_transport, rpc_transport);
+```
 
+See the [trait map](crate::guide::trait_map) for the public API relationships.
 
-For which trait is which, see the [trait map](crate::guide::trait_map).
+## Handle failures by API
+
+* [`UStatus`](crate::UStatus) is returned by Transport Layer operations. For
+  example, [`UTransport::send`](crate::UTransport::send) can reject an invalid
+  message with [`UCode::InvalidArgument`](crate::UCode::InvalidArgument) or
+  report an unavailable transport with
+  [`UCode::Unavailable`](crate::UCode::Unavailable).
+* [`RegistrationError`](crate::communication::RegistrationError) is returned
+  when a Communication Layer listener, subscriber, RPC client, or RPC endpoint
+  cannot be registered or unregistered.
+* [`PubSubError`](crate::communication::PubSubError),
+  [`NotificationError`](crate::communication::NotificationError), and
+  [`ServiceInvocationError`](crate::communication::ServiceInvocationError) are
+  returned by Communication Layer role operations. The publish and notification
+  transport-failure variants wrap a [`UStatus`](crate::UStatus), while RPC
+  transport and response statuses are converted into `ServiceInvocationError`
+  variants. For example,
+  [`ServiceInvocationError::DeadlineExceeded`](crate::communication::ServiceInvocationError::DeadlineExceeded)
+  reports an RPC timeout.
+
+For RPC, both a transport `UStatus` and a response's non-OK communication status
+use the same [`ServiceInvocationError`](crate::communication::ServiceInvocationError)
+mapping. A client-side timeout returns
+[`ServiceInvocationError::DeadlineExceeded`](crate::communication::ServiceInvocationError::DeadlineExceeded).
+
+## Next steps
+
+* [Communication Layer roles](crate::guide::applications::communication)
+* [Direct Transport Layer use](crate::guide::applications::transport)
+* [Public trait relationships](crate::guide::trait_map)

--- a/src/guide/applications.md
+++ b/src/guide/applications.md
@@ -1,0 +1,83 @@
+# Writing an application
+
+Applications talk uProtocol through one of **two layers**, and knowing
+which one you're on is the whole orientation:
+
+* **[The Communication Layer](crate::guide::applications::communication)**
+  (up-L2, feature `communication`) — role traits: `Publisher`,
+  `Subscriber`, `Notifier`, `RpcClient`, `RpcServer`. **This is the
+  recommended starting point.** Start here unless you have a reason not to.
+* **[The Transport Layer](crate::guide::applications::transport)**
+  (up-L1, no features) — build [`UMessage`](crate::UMessage)s yourself
+  and hand them to a [`UTransport`](crate::UTransport). The floor the
+  roles stand on; yours directly when you need minimal dependencies,
+  custom filtering, or direct control over message construction.
+
+Thirty seconds to first message, on the communication layer:
+
+```rust
+use std::sync::Arc;
+use up_rust::local_transport::LocalTransport;
+use up_rust::{StaticUriProvider, UPayloadFormat};
+use up_rust::communication::{CallOptions, Publisher, SimplePublisher, UPayload};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transport = Arc::new(LocalTransport::default());
+    let me = Arc::new(StaticUriProvider::new("my-vehicle", 0x1_0001, 1)?);
+
+    SimplePublisher::new(transport, me)
+        .publish(0x8001, CallOptions::for_publish(None, None, None),
+                 Some(UPayload::new("92.5", UPayloadFormat::Text)))
+        .await?;
+    // Delivered to every subscriber of my-vehicle/0x1_0001/1/0x8001.
+    Ok(())
+}
+```
+
+Everything below applies to both layers.
+
+## Addresses in one box
+
+Every example below uses [`UUri`](crate::UUri) literals; here is what
+they mean, once:
+
+```text
+UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)
+                      authority    entity   ver resource
+```
+
+* **authority** — which device/domain the uEntity lives on.
+* **entity id** — which uEntity (a u32; deployments assign these).
+* **major version** — the uEntity's API major version.
+* **resource id** — *what* within the uEntity: `0x0000` is the uEntity
+  itself (the address RPC responses return to), ids `0x0001..=0x7FFF`
+  are RPC **methods**, and ids **`0x8000..=0xFFFE` are topics** a uEntity
+  publishes. `0xFFFF` is the wildcard. That is why the publish examples
+  use `0x8001` and the RPC endpoint uses `0x00A1`.
+
+## When things fail
+
+Every operation returns a code you can act on. Transport-level errors
+arrive as [`UStatus`](crate::UStatus) carrying a [`UCode`](crate::UCode):
+`Unavailable` (link down — retry with backoff), `AlreadyExists`
+(duplicate listener registration), `InvalidArgument` (a filter or
+message the transport cannot express), `PermissionDenied`. The roles
+wrap these: publishing fails with `PubSubError`, RPC with
+`ServiceInvocationError` — whose `CommStatus` variant means *the remote
+service* answered with a failure code, distinct from the transport
+failing to deliver. Timeouts surface as `CommStatus(DeadlineExceeded)`
+when the `ttl` you passed in `CallOptions` expires.
+
+## Where a real transport comes from
+
+The examples use `LocalTransport` so they can run anywhere. In a
+deployment, you construct one of the transport crates at startup —
+`up-transport-zenoh-rust`, `up-transport-mqtt5-rust`,
+`up-transport-vsomeip-rust`, and so on — configure it, wrap it in an
+`Arc`, and hand that same `Arc` to every role. Application code stays
+transport-agnostic: the role implementations are generic over
+`UTransport`, which is the point of the protocol.
+
+
+For which trait is which, see the [trait map](crate::guide::trait_map).

--- a/src/guide/communication.md
+++ b/src/guide/communication.md
@@ -1,49 +1,73 @@
-# The Communication Layer (up-L2)
+# Communication Layer roles
 
-The roles hide message building entirely: you say *what* (publish this,
-call that) and the layer builds, addresses, and correlates the messages
-over whatever transport it was given. Enable `communication`.
+Use five Communication Layer role traits across four messaging patterns:
 
-## Publishing
+* publish events;
+* subscribe to events;
+* send one-way notifications; and
+* invoke or serve RPC methods.
 
-The hub page's quickstart is the whole pattern; here it is again with
-the pieces named — `LocalTransport` is the in-process transport the
-examples use:
+Enable the Cargo features used by the examples with:
+
+```bash
+cargo add up-rust --features communication,util
+```
+
+The `communication` feature enables the role APIs. The `util` feature provides
+the in-memory transport used by the examples.
+
+## Publish events
+
+[`Publisher`](crate::communication::Publisher) creates publish messages from a
+resource ID, call options, and an optional payload. The publishing example uses
+this in-process transport:
 
 ```rust
 use std::sync::Arc;
+use up_rust::communication::{CallOptions, PubSubError, Publisher, SimplePublisher, UPayload};
 use up_rust::local_transport::LocalTransport;
-use up_rust::StaticUriProvider;
-use up_rust::communication::{CallOptions, Publisher, SimplePublisher, UPayload};
-use up_rust::UPayloadFormat;
+use up_rust::{StaticUriProvider, UPayloadFormat};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), PubSubError> {
     let transport = Arc::new(LocalTransport::default());
-    let identity = Arc::new(StaticUriProvider::new("my-vehicle", 0x1_0001, 1)?);
+    let identity = Arc::new(
+        StaticUriProvider::new("my-vehicle", 0x1_0001, 1)
+            .expect("valid publisher identity"),
+    );
 
     let publisher = SimplePublisher::new(transport, identity);
     let payload = UPayload::new("92.5", UPayloadFormat::Text);
     publisher
-        .publish(0x8001, CallOptions::for_publish(None, None, None), Some(payload))
+        .publish(
+            0x8001,
+            CallOptions::for_publish(None, None, None),
+            Some(payload),
+        )
         .await?;
-    // Delivered to every subscriber of my-vehicle/0x1_0001/1/0x8001.
     Ok(())
 }
 ```
 
-## Subscribing (and why it needs a service)
+[`UTransport::send`](crate::UTransport::send) dispatches the message to matching
+listeners when implemented by
+[`LocalTransport`](crate::local_transport::LocalTransport). A deployed transport
+maps the same Transport Layer operation to its protocol.
 
-Publish, notify, and RPC are pure transport interactions. **Subscription
-is different by design**: uProtocol tracks who subscribes to what in a
-service — uSubscription — so subscriptions survive reconnects and can be
-observed. The [`Subscriber`](crate::communication::Subscriber) role
-therefore needs two collaborators: a transport *and* a uSubscription
-client.
+## Subscribe to events
+
+[`Subscriber`](crate::communication::Subscriber) registers listeners for a
+topic pattern. [`InMemorySubscriber`](crate::communication::InMemorySubscriber)
+implements [`Subscriber::subscribe`](crate::communication::Subscriber::subscribe)
+using the uSubscription service to create a subscription record containing a
+topic and subscriber URI. The service reports subscription state changes to the
+subscriber URI. The in-memory subscriber's local listener registrations remain
+process-local, so this example is `no_run` unless the configured transport can
+reach a uSubscription service.
 
 ```rust,no_run
 # use std::sync::Arc;
-# use up_rust::communication::Subscriber as _;
+# use up_rust::communication::{RegistrationError, Subscriber as _};
 # use up_rust::{LocalUriProvider, UListener, UMessage, UTransport, UUri};
 use up_rust::communication::InMemorySubscriber;
 # struct TempListener;
@@ -55,42 +79,45 @@ use up_rust::communication::InMemorySubscriber;
 #     transport: Arc<T>,
 #     identity: Arc<P>,
 #     topic: UUri,
-# ) -> Result<(), Box<dyn std::error::Error>>
+# ) -> Result<(), RegistrationError>
 # where
 #     T: UTransport + 'static,
 #     P: LocalUriProvider + 'static,
 # {
-
-// `new` wires the uSubscription client for you: an RPC client over your
-// transport, talking to the uSubscription service in your deployment.
 let subscriber = InMemorySubscriber::new(transport, identity).await?;
-
-subscriber.subscribe(&topic, Arc::new(TempListener), None).await?;
+subscriber
+    .subscribe(&topic, Arc::new(TempListener), None)
+    .await?;
 # Ok(())
 # }
 ```
 
-A real subscription round-trips through the uSubscription service, so
-this compiles against your deployment's transport and RPC client rather
-than running standalone; for unit tests, `test-util` provides role
-mocks.
+Both [`InMemorySubscriber::new`](crate::communication::InMemorySubscriber::new)
+and [`Subscriber::subscribe`](crate::communication::Subscriber::subscribe)
+return [`RegistrationError`](crate::communication::RegistrationError).
 
-## Notifying one receiver
+## Send a notification
 
-Publish goes to whoever subscribed; a *notification* targets one uEntity.
-Same shape, one extra argument:
+[`Notifier`](crate::communication::Notifier) sends a one-way message to one
+uEntity rather than publishing to a topic's subscribers:
 
 ```rust
 use std::sync::Arc;
+use up_rust::communication::{
+    CallOptions, NotificationError, Notifier, SimpleNotifier, UPayload,
+};
 use up_rust::local_transport::LocalTransport;
 use up_rust::{StaticUriProvider, UPayloadFormat, UUri};
-use up_rust::communication::{CallOptions, Notifier, SimpleNotifier, UPayload};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), NotificationError> {
     let transport = Arc::new(LocalTransport::default());
-    let identity = Arc::new(StaticUriProvider::new("my-vehicle", 0x1_0001, 1)?);
-    let destination = UUri::try_from_parts("my-vehicle", 0x2_0002, 1, 0x0000)?;
+    let identity = Arc::new(
+        StaticUriProvider::new("my-vehicle", 0x1_0001, 1)
+            .expect("valid notifier identity"),
+    );
+    let destination = UUri::try_from_parts("my-vehicle", 0x2_0002, 1, 0x0000)
+        .expect("valid notification destination");
 
     let notifier = SimpleNotifier::new(transport, identity);
     notifier
@@ -101,23 +128,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(UPayload::new("door open", UPayloadFormat::Text)),
         )
         .await?;
-    // Exactly one receiver: the uEntity at `destination` — not a topic fan-out.
     Ok(())
 }
 ```
 
-## Serving RPC
+## Serve RPC requests
 
-You expose a resource id and a handler; the server owns listener
-registration and response addressing:
+[`RpcServer`](crate::communication::RpcServer) registers a
+[`RequestHandler`](crate::communication::RequestHandler) for a resource ID. The
+server builds and addresses each response. This `no_run` example remains alive
+after registration so the server and transport can continue receiving requests;
+a deployed service would await its shutdown signal instead:
 
-```rust
+```rust,no_run
 use std::sync::Arc;
+use up_rust::communication::{
+    InMemoryRpcServer, RegistrationError, RequestHandler, RpcServer,
+    ServiceInvocationError, UPayload,
+};
 use up_rust::local_transport::LocalTransport;
 use up_rust::{StaticUriProvider, UAttributes};
-use up_rust::communication::{
-    InMemoryRpcServer, RequestHandler, RpcServer, ServiceInvocationError, UPayload,
-};
 
 struct EchoHandler;
 
@@ -129,40 +159,47 @@ impl RequestHandler for EchoHandler {
         _attributes: &UAttributes,
         request: Option<UPayload>,
     ) -> Result<Option<UPayload>, ServiceInvocationError> {
-        Ok(request) // echo the request payload back
+        Ok(request)
     }
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), RegistrationError> {
     let transport = Arc::new(LocalTransport::default());
-    let service = Arc::new(StaticUriProvider::new("my-vehicle", 0x2_0002, 1)?);
+    let service = Arc::new(
+        StaticUriProvider::new("my-vehicle", 0x2_0002, 1)
+            .expect("valid RPC service identity"),
+    );
 
     let server = InMemoryRpcServer::new(transport, service);
-    server.register_endpoint(None, 0x00A1, Arc::new(EchoHandler)).await?;
-    // The service now answers requests to my-vehicle/0x2_0002/1/0x00A1.
+    server
+        .register_endpoint(None, 0x00A1, Arc::new(EchoHandler))
+        .await?;
+
+    std::future::pending::<()>().await;
     Ok(())
 }
 ```
 
-Return `Err(ServiceInvocationError::...)` from the handler and the
-caller receives it as a `CommStatus` — an application-level failure,
-delivered, not a transport failure.
+[`RpcServer::register_endpoint`](crate::communication::RpcServer::register_endpoint)
+completes after installing the handler. Keep the server and transport alive
+until the service shuts down.
 
-## Calling RPC
+## Invoke an RPC method
 
-The client correlates responses to requests and enforces your deadline.
-(The inline echo service here is scaffolding so the round trip can run
-and assert; in a deployment it's someone else's uEntity.)
+[`RpcClient`](crate::communication::RpcClient) correlates the response with its
+request and enforces the request TTL. This example registers an echo endpoint in
+the same process; a deployed client calls the target uEntity through its
+configured transport.
 
 ```rust
 use std::sync::Arc;
-use up_rust::local_transport::LocalTransport;
-use up_rust::{LocalUriProvider, StaticUriProvider, UAttributes, UPayloadFormat};
 use up_rust::communication::{
     CallOptions, InMemoryRpcClient, InMemoryRpcServer, RequestHandler, RpcClient, RpcServer,
     ServiceInvocationError, UPayload,
 };
+use up_rust::local_transport::LocalTransport;
+use up_rust::{LocalUriProvider, StaticUriProvider, UAttributes, UPayloadFormat};
 
 # struct EchoHandler;
 # #[async_trait::async_trait]
@@ -173,26 +210,73 @@ use up_rust::communication::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let transport = Arc::new(LocalTransport::default());
-    let service = Arc::new(StaticUriProvider::new("my-vehicle", 0x2_0002, 1)?);
-    # let server = InMemoryRpcServer::new(transport.clone(), service.clone());
-    # server.register_endpoint(None, 0x00A1, Arc::new(EchoHandler)).await?;
+    let service = Arc::new(
+        StaticUriProvider::new("my-vehicle", 0x2_0002, 1)
+            .expect("valid RPC service identity"),
+    );
+    let server = InMemoryRpcServer::new(transport.clone(), service.clone());
+    server
+        .register_endpoint(None, 0x00A1, Arc::new(EchoHandler))
+        .await?;
 
-    let me = Arc::new(StaticUriProvider::new("my-vehicle", 0x3_0003, 1)?);
-    let client = InMemoryRpcClient::new(transport, me).await?;
+    let identity = Arc::new(
+        StaticUriProvider::new("my-vehicle", 0x3_0003, 1)
+            .expect("valid RPC client identity"),
+    );
+    let client = InMemoryRpcClient::new(transport, identity).await?;
 
     let response = client
         .invoke_method(
             service.get_resource_uri(0x00A1),
-            CallOptions::for_rpc_request(5_000, None, None, None), // 5s deadline
+            CallOptions::for_rpc_request(5_000, None, None, None),
             Some(UPayload::new("ping", UPayloadFormat::Text)),
         )
         .await?;
 
-    assert_eq!(response.unwrap().payload(), "ping");
+    assert_eq!(
+        response.expect("echo response contains a payload").payload(),
+        "ping"
+    );
     Ok(())
 }
 ```
 
-If the deadline passes first, `invoke_method` returns
-`CommStatus(DeadlineExceeded)` — see
-[when things fail](crate::guide::applications) on the hub.
+This combined example uses `Box<dyn Error>` because RPC setup returns
+[`RegistrationError`](crate::communication::RegistrationError), while method
+invocation returns
+[`ServiceInvocationError`](crate::communication::ServiceInvocationError).
+
+## Handle role errors
+
+The Communication Layer reports role-specific errors:
+
+* [`RegistrationError`](crate::communication::RegistrationError) — a listener,
+  subscriber, RPC client, or RPC endpoint could not be registered or
+  unregistered;
+* [`PubSubError::InvalidArgument`](crate::communication::PubSubError::InvalidArgument),
+  [`NotificationError::InvalidArgument`](crate::communication::NotificationError::InvalidArgument),
+  and [`ServiceInvocationError::InvalidArgument`](crate::communication::ServiceInvocationError::InvalidArgument)
+  — URI, priority, TTL, or role input is invalid;
+* [`PubSubError::PublishError`](crate::communication::PubSubError::PublishError)
+  and [`NotificationError::NotifyError`](crate::communication::NotificationError::NotifyError)
+  — the publish or notification transport operation returned a
+  [`UStatus`](crate::UStatus);
+* [`ServiceInvocationError::DeadlineExceeded`](crate::communication::ServiceInvocationError::DeadlineExceeded)
+  — the RPC client did not receive a matching response before the TTL elapsed;
+* other [`ServiceInvocationError`](crate::communication::ServiceInvocationError)
+  variants — an RPC transport operation or response produced the corresponding
+  status. A status without a dedicated variant becomes
+  [`ServiceInvocationError::RpcError`](crate::communication::ServiceInvocationError::RpcError).
+
+Correct invalid input, retry failures according to the application's policy,
+and handle RPC response errors according to their
+[`ServiceInvocationError`](crate::communication::ServiceInvocationError)
+variant.
+
+## Next steps
+
+Use [the Transport Layer](crate::guide::applications::transport) directly for
+exact [`UMessage`](crate::UMessage) control, custom listener filters, or
+transport infrastructure. See
+[application error handling](crate::guide::applications) and the
+[trait map](crate::guide::trait_map) for the public API relationships.

--- a/src/guide/communication.md
+++ b/src/guide/communication.md
@@ -1,0 +1,198 @@
+# The Communication Layer (up-L2)
+
+The roles hide message building entirely: you say *what* (publish this,
+call that) and the layer builds, addresses, and correlates the messages
+over whatever transport it was given. Enable `communication`.
+
+## Publishing
+
+The hub page's quickstart is the whole pattern; here it is again with
+the pieces named — `LocalTransport` is the in-process transport the
+examples use:
+
+```rust
+use std::sync::Arc;
+use up_rust::local_transport::LocalTransport;
+use up_rust::StaticUriProvider;
+use up_rust::communication::{CallOptions, Publisher, SimplePublisher, UPayload};
+use up_rust::UPayloadFormat;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transport = Arc::new(LocalTransport::default());
+    let identity = Arc::new(StaticUriProvider::new("my-vehicle", 0x1_0001, 1)?);
+
+    let publisher = SimplePublisher::new(transport, identity);
+    let payload = UPayload::new("92.5", UPayloadFormat::Text);
+    publisher
+        .publish(0x8001, CallOptions::for_publish(None, None, None), Some(payload))
+        .await?;
+    // Delivered to every subscriber of my-vehicle/0x1_0001/1/0x8001.
+    Ok(())
+}
+```
+
+## Subscribing (and why it needs a service)
+
+Publish, notify, and RPC are pure transport interactions. **Subscription
+is different by design**: uProtocol tracks who subscribes to what in a
+service — uSubscription — so subscriptions survive reconnects and can be
+observed. The [`Subscriber`](crate::communication::Subscriber) role
+therefore needs two collaborators: a transport *and* a uSubscription
+client.
+
+```rust,no_run
+# use std::sync::Arc;
+# use up_rust::communication::Subscriber as _;
+# use up_rust::{LocalUriProvider, UListener, UMessage, UTransport, UUri};
+use up_rust::communication::InMemorySubscriber;
+# struct TempListener;
+# #[async_trait::async_trait]
+# impl UListener for TempListener {
+#     async fn on_receive(&self, _message: UMessage) {}
+# }
+# async fn wire_up<T, P>(
+#     transport: Arc<T>,
+#     identity: Arc<P>,
+#     topic: UUri,
+# ) -> Result<(), Box<dyn std::error::Error>>
+# where
+#     T: UTransport + 'static,
+#     P: LocalUriProvider + 'static,
+# {
+
+// `new` wires the uSubscription client for you: an RPC client over your
+// transport, talking to the uSubscription service in your deployment.
+let subscriber = InMemorySubscriber::new(transport, identity).await?;
+
+subscriber.subscribe(&topic, Arc::new(TempListener), None).await?;
+# Ok(())
+# }
+```
+
+A real subscription round-trips through the uSubscription service, so
+this compiles against your deployment's transport and RPC client rather
+than running standalone; for unit tests, `test-util` provides role
+mocks.
+
+## Notifying one receiver
+
+Publish goes to whoever subscribed; a *notification* targets one uEntity.
+Same shape, one extra argument:
+
+```rust
+use std::sync::Arc;
+use up_rust::local_transport::LocalTransport;
+use up_rust::{StaticUriProvider, UPayloadFormat, UUri};
+use up_rust::communication::{CallOptions, Notifier, SimpleNotifier, UPayload};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transport = Arc::new(LocalTransport::default());
+    let identity = Arc::new(StaticUriProvider::new("my-vehicle", 0x1_0001, 1)?);
+    let destination = UUri::try_from_parts("my-vehicle", 0x2_0002, 1, 0x0000)?;
+
+    let notifier = SimpleNotifier::new(transport, identity);
+    notifier
+        .notify(
+            0x8002,
+            &destination,
+            CallOptions::for_notification(None, None, None),
+            Some(UPayload::new("door open", UPayloadFormat::Text)),
+        )
+        .await?;
+    // Exactly one receiver: the uEntity at `destination` — not a topic fan-out.
+    Ok(())
+}
+```
+
+## Serving RPC
+
+You expose a resource id and a handler; the server owns listener
+registration and response addressing:
+
+```rust
+use std::sync::Arc;
+use up_rust::local_transport::LocalTransport;
+use up_rust::{StaticUriProvider, UAttributes};
+use up_rust::communication::{
+    InMemoryRpcServer, RequestHandler, RpcServer, ServiceInvocationError, UPayload,
+};
+
+struct EchoHandler;
+
+#[async_trait::async_trait]
+impl RequestHandler for EchoHandler {
+    async fn handle_request(
+        &self,
+        _resource_id: u16,
+        _attributes: &UAttributes,
+        request: Option<UPayload>,
+    ) -> Result<Option<UPayload>, ServiceInvocationError> {
+        Ok(request) // echo the request payload back
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transport = Arc::new(LocalTransport::default());
+    let service = Arc::new(StaticUriProvider::new("my-vehicle", 0x2_0002, 1)?);
+
+    let server = InMemoryRpcServer::new(transport, service);
+    server.register_endpoint(None, 0x00A1, Arc::new(EchoHandler)).await?;
+    // The service now answers requests to my-vehicle/0x2_0002/1/0x00A1.
+    Ok(())
+}
+```
+
+Return `Err(ServiceInvocationError::...)` from the handler and the
+caller receives it as a `CommStatus` — an application-level failure,
+delivered, not a transport failure.
+
+## Calling RPC
+
+The client correlates responses to requests and enforces your deadline.
+(The inline echo service here is scaffolding so the round trip can run
+and assert; in a deployment it's someone else's uEntity.)
+
+```rust
+use std::sync::Arc;
+use up_rust::local_transport::LocalTransport;
+use up_rust::{LocalUriProvider, StaticUriProvider, UAttributes, UPayloadFormat};
+use up_rust::communication::{
+    CallOptions, InMemoryRpcClient, InMemoryRpcServer, RequestHandler, RpcClient, RpcServer,
+    ServiceInvocationError, UPayload,
+};
+
+# struct EchoHandler;
+# #[async_trait::async_trait]
+# impl RequestHandler for EchoHandler {
+#     async fn handle_request(&self, _r: u16, _a: &UAttributes, req: Option<UPayload>)
+#         -> Result<Option<UPayload>, ServiceInvocationError> { Ok(req) }
+# }
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transport = Arc::new(LocalTransport::default());
+    let service = Arc::new(StaticUriProvider::new("my-vehicle", 0x2_0002, 1)?);
+    # let server = InMemoryRpcServer::new(transport.clone(), service.clone());
+    # server.register_endpoint(None, 0x00A1, Arc::new(EchoHandler)).await?;
+
+    let me = Arc::new(StaticUriProvider::new("my-vehicle", 0x3_0003, 1)?);
+    let client = InMemoryRpcClient::new(transport, me).await?;
+
+    let response = client
+        .invoke_method(
+            service.get_resource_uri(0x00A1),
+            CallOptions::for_rpc_request(5_000, None, None, None), // 5s deadline
+            Some(UPayload::new("ping", UPayloadFormat::Text)),
+        )
+        .await?;
+
+    assert_eq!(response.unwrap().payload(), "ping");
+    Ok(())
+}
+```
+
+If the deadline passes first, `invoke_method` returns
+`CommStatus(DeadlineExceeded)` — see
+[when things fail](crate::guide::applications) on the hub.

--- a/src/guide/trait_map.md
+++ b/src/guide/trait_map.md
@@ -1,61 +1,62 @@
-# The trait map: how the traits fit together
+# Public trait map
 
-The crate's behavioral traits form a small system: one transport contract, one
-delivery callback, five Communication Layer roles with one request handler, one
-subscription callback, and three supporting utilities. This page is the
-one-screen overview.
+* The **Communication Layer** provides the application roles.
+* The **Transport Layer** provides direct [`UMessage`](crate::UMessage) send,
+  push-listener, and pull-receive operations.
+* Transport bindings implement [`UTransport`](crate::UTransport).
+* [`LocalUriProvider`](crate::LocalUriProvider) separately supplies the local
+  uEntity identity used to address messages.
 
-## The stack in five lines
+## Layers
 
-```text
-application            roles (up-L2)  or  UMessage + UTransport (up-L1)
-                                  |
-transport contract     UTransport
-                                  |
-technology             broker, bus, shared memory
-```
+| Layer | Main API | Implemented by | Use |
+| --- | --- | --- | --- |
+| Application roles | [`Publisher`](crate::communication::Publisher), [`Subscriber`](crate::communication::Subscriber), [`Notifier`](crate::communication::Notifier), [`RpcClient`](crate::communication::RpcClient), [`RpcServer`](crate::communication::RpcServer) | applications or the crate's ready-made implementations | Publish, subscribe, notify, invoke, or serve |
+| Move messages | [`UTransport`](crate::UTransport) | implemented by the transport | Direct send, push-listener, or pull-receive control; transport infrastructure |
+| Consume push delivery | [`UListener`](crate::UListener) | applications and Communication Layer implementations | Receive messages selected by transport filters |
+| Identify the local uEntity | [`LocalUriProvider`](crate::LocalUriProvider) | application or deployment configuration | Supply source and response addresses |
 
-## The Transport Layer (up-L1)
+The Communication Layer depends on the Transport Layer. Its role APIs are
+generic over [`UTransport`](crate::UTransport), so they can use an in-memory or
+protocol-backed implementation.
 
-| Trait | Implemented by | Called by |
+## Communication Layer implementations
+
+The `communication` Cargo feature enables the ready-made role implementations:
+
+| Role trait | Implementation | Additional collaborator |
 | --- | --- | --- |
-| [`UTransport`](crate::UTransport) | transport providers (broker/bus bindings) | applications and the Communication Layer |
-| [`UListener`](crate::UListener) | message consumers | the transport, on delivery |
+| [`Publisher`](crate::communication::Publisher) | [`SimplePublisher`](crate::communication::SimplePublisher) | — |
+| [`Subscriber`](crate::communication::Subscriber) | [`InMemorySubscriber`](crate::communication::InMemorySubscriber) | uSubscription service |
+| [`Notifier`](crate::communication::Notifier) | [`SimpleNotifier`](crate::communication::SimpleNotifier) | — |
+| [`RpcClient`](crate::communication::RpcClient) | [`InMemoryRpcClient`](crate::communication::InMemoryRpcClient) | — |
+| [`RpcServer`](crate::communication::RpcServer) | [`InMemoryRpcServer`](crate::communication::InMemoryRpcServer) | [`RequestHandler`](crate::communication::RequestHandler) |
 
-[`UTransport`](crate::UTransport) is the floor: `send` a
-[`UMessage`](crate::UMessage), or `register_listener` for a source/sink filter
-pair. Everything above is built from those operations.
+## Operations
 
-## The Communication Layer roles (up-L2)
-
-Applications usually use the role traits rather than building messages by
-hand. The ready-made implementations below drive a [`UTransport`](crate::UTransport)
-(feature `up-l2-api` for the traits, `communication` for every implementation):
-
-| You want to... | Role trait | Ready-made implementation |
+| Task | Primary method | Collaborator |
 | --- | --- | --- |
-| Publish to whoever listens | [`Publisher`](crate::communication::Publisher) | [`SimplePublisher`](crate::communication::SimplePublisher) |
-| Target one uEntity | [`Notifier`](crate::communication::Notifier) | [`SimpleNotifier`](crate::communication::SimpleNotifier) |
-| Consume a topic | [`Subscriber`](crate::communication::Subscriber) | [`InMemorySubscriber`](crate::communication::InMemorySubscriber) (needs uSubscription; see [the application tutorial](crate::guide::applications)) |
-| Call a service | [`RpcClient`](crate::communication::RpcClient) | [`InMemoryRpcClient`](crate::communication::InMemoryRpcClient) |
-| Serve requests | [`RpcServer`](crate::communication::RpcServer) + [`RequestHandler`](crate::communication::RequestHandler) | [`InMemoryRpcServer`](crate::communication::InMemoryRpcServer) |
+| Publish an event | [`Publisher::publish`](crate::communication::Publisher::publish) | [`CallOptions`](crate::communication::CallOptions) |
+| Subscribe to a topic | [`Subscriber::subscribe`](crate::communication::Subscriber::subscribe) | [`UListener`](crate::UListener) and uSubscription |
+| Send a notification | [`Notifier::notify`](crate::communication::Notifier::notify) | [`CallOptions`](crate::communication::CallOptions) |
+| Invoke an RPC method | [`RpcClient::invoke_method`](crate::communication::RpcClient::invoke_method) | [`CallOptions`](crate::communication::CallOptions) |
+| Serve an RPC method | [`RpcServer::register_endpoint`](crate::communication::RpcServer::register_endpoint) | [`RequestHandler`](crate::communication::RequestHandler) |
+| Push a raw message | [`UTransport::send`](crate::UTransport::send) | — |
+| Receive raw messages by push | [`UTransport::register_listener`](crate::UTransport::register_listener) | [`UListener`](crate::UListener) |
+| Receive one raw message by pull | [`UTransport::receive`](crate::UTransport::receive) | — |
 
-Each role owns message construction for its message type. Use the roles and you
-do not touch [`UMessageBuilder`](crate::UMessageBuilder); use the Transport Layer
-directly and message construction is yours.
-
-## Supporting hooks and utilities
+## Supporting APIs
 
 * [`SubscriptionChangeHandler`](crate::communication::SubscriptionChangeHandler)
   receives subscription-state callbacks.
-* [`LocalUriProvider`](crate::LocalUriProvider) answers "what is *my* address?";
-  the role implementations use it to build source URIs.
-* [`ProtobufMappable`](crate::ProtobufMappable) lets protobuf-generated types
-  ride as payloads implicitly (feature `protobuf-support`).
+* [`UMessageBuilder`](crate::UMessageBuilder) builds messages for direct
+  Transport Layer use.
 * [`UAttributesValidator`](crate::UAttributesValidator) validates message
-  attributes by message kind; transports use it at their boundaries.
+  attributes by message kind.
+* [`ProtobufMappable`](crate::ProtobufMappable) integrates protobuf-generated
+  payload types when the `protobuf-support` feature is enabled.
 
-## Where to go
+## Related guides
 
 Applications: [the application tutorial](crate::guide::applications).
 Transport users: [the Transport Layer tutorial](crate::guide::applications::transport).

--- a/src/guide/trait_map.md
+++ b/src/guide/trait_map.md
@@ -1,0 +1,62 @@
+# The trait map: how the traits fit together
+
+The crate's behavioral traits form a small system: one transport contract, one
+delivery callback, five Communication Layer roles with one request handler, one
+subscription callback, and three supporting utilities. This page is the
+one-screen overview.
+
+## The stack in five lines
+
+```text
+application            roles (up-L2)  or  UMessage + UTransport (up-L1)
+                                  |
+transport contract     UTransport
+                                  |
+technology             broker, bus, shared memory
+```
+
+## The Transport Layer (up-L1)
+
+| Trait | Implemented by | Called by |
+| --- | --- | --- |
+| [`UTransport`](crate::UTransport) | transport providers (broker/bus bindings) | applications and the Communication Layer |
+| [`UListener`](crate::UListener) | message consumers | the transport, on delivery |
+
+[`UTransport`](crate::UTransport) is the floor: `send` a
+[`UMessage`](crate::UMessage), or `register_listener` for a source/sink filter
+pair. Everything above is built from those operations.
+
+## The Communication Layer roles (up-L2)
+
+Applications usually use the role traits rather than building messages by
+hand. The ready-made implementations below drive a [`UTransport`](crate::UTransport)
+(feature `up-l2-api` for the traits, `communication` for every implementation):
+
+| You want to... | Role trait | Ready-made implementation |
+| --- | --- | --- |
+| Publish to whoever listens | [`Publisher`](crate::communication::Publisher) | [`SimplePublisher`](crate::communication::SimplePublisher) |
+| Target one uEntity | [`Notifier`](crate::communication::Notifier) | [`SimpleNotifier`](crate::communication::SimpleNotifier) |
+| Consume a topic | [`Subscriber`](crate::communication::Subscriber) | [`InMemorySubscriber`](crate::communication::InMemorySubscriber) (needs uSubscription; see [the application tutorial](crate::guide::applications)) |
+| Call a service | [`RpcClient`](crate::communication::RpcClient) | [`InMemoryRpcClient`](crate::communication::InMemoryRpcClient) |
+| Serve requests | [`RpcServer`](crate::communication::RpcServer) + [`RequestHandler`](crate::communication::RequestHandler) | [`InMemoryRpcServer`](crate::communication::InMemoryRpcServer) |
+
+Each role owns message construction for its message type. Use the roles and you
+do not touch [`UMessageBuilder`](crate::UMessageBuilder); use the Transport Layer
+directly and message construction is yours.
+
+## Supporting hooks and utilities
+
+* [`SubscriptionChangeHandler`](crate::communication::SubscriptionChangeHandler)
+  receives subscription-state callbacks.
+* [`LocalUriProvider`](crate::LocalUriProvider) answers "what is *my* address?";
+  the role implementations use it to build source URIs.
+* [`ProtobufMappable`](crate::ProtobufMappable) lets protobuf-generated types
+  ride as payloads implicitly (feature `protobuf-support`).
+* [`UAttributesValidator`](crate::UAttributesValidator) validates message
+  attributes by message kind; transports use it at their boundaries.
+
+## Where to go
+
+Applications: [the application tutorial](crate::guide::applications).
+Transport users: [the Transport Layer tutorial](crate::guide::applications::transport).
+Transport authors: [the transport implementation tutorial](crate::guide::utransport).

--- a/src/guide/trait_map_core.md
+++ b/src/guide/trait_map_core.md
@@ -1,0 +1,37 @@
+# Public trait map
+
+The Transport Layer API is always available. Enable the aggregate
+`communication` Cargo feature for the complete Communication Layer role and
+implementation map.
+
+## Layers
+
+| Layer | Main API | Implemented by | Use |
+| --- | --- | --- | --- |
+| Move messages | [`UTransport`](crate::UTransport) | transport implementation | Direct send, push-listener, or pull-receive control |
+| Consume push delivery | [`UListener`](crate::UListener) | application or higher layer | Receive messages selected by transport filters |
+| Identify the local uEntity | [`LocalUriProvider`](crate::LocalUriProvider) | application or deployment configuration, separately from `UTransport` | Supply source and response addresses |
+
+## Operations
+
+| Task | Primary method |
+| --- | --- |
+| Send a message | [`UTransport::send`](crate::UTransport::send) |
+| Register for push delivery | [`UTransport::register_listener`](crate::UTransport::register_listener) |
+| Stop push delivery | [`UTransport::unregister_listener`](crate::UTransport::unregister_listener) |
+| Receive one message by pull | [`UTransport::receive`](crate::UTransport::receive) |
+
+## Supporting APIs
+
+* [`UMessageBuilder`](crate::UMessageBuilder) builds messages for direct
+  Transport Layer use.
+* [`UUri`](crate::UUri) identifies resources and supplies listener filters.
+* [`UAttributesValidator`](crate::UAttributesValidator) validates message
+  attributes by message kind.
+* [`UStatus`](crate::UStatus) reports Transport Layer failures.
+
+## Related guides
+
+Applications: [the application guide](crate::guide::applications).
+Transport users: [direct Transport Layer use](crate::guide::applications::transport).
+Transport authors: [implementing a transport](crate::guide::utransport).

--- a/src/guide/transport.md
+++ b/src/guide/transport.md
@@ -1,0 +1,66 @@
+# The Transport Layer (up-L1)
+
+Sometimes you want the floor itself: no role features, no protobuf, no runtime
+beyond your own — just build a [`UMessage`](crate::UMessage) and hand it to the
+[`UTransport`](crate::UTransport) your deployment configured.
+
+## Publish
+
+```rust
+use up_rust::{UMessageBuilder, UPayloadFormat, UTransport, UUri};
+
+async fn publish(transport: &dyn UTransport) -> Result<(), Box<dyn std::error::Error>> {
+    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
+    let message = UMessageBuilder::publish(topic)
+        .build_with_payload("92.5", UPayloadFormat::Text)?;
+    transport.send(message).await?;
+    Ok(())
+}
+```
+
+## Receive
+
+```rust
+use std::sync::Arc;
+use up_rust::{UListener, UMessage, UTransport, UUri};
+
+struct TempListener;
+
+#[async_trait::async_trait]
+impl UListener for TempListener {
+    async fn on_receive(&self, message: UMessage) {
+        // Prints: engine temp update: Some(b"92.5") for the publish above.
+        println!("engine temp update: {:?}", message.payload());
+    }
+}
+
+async fn subscribe(transport: &dyn UTransport) -> Result<(), Box<dyn std::error::Error>> {
+    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
+    transport.register_listener(&topic, None, Arc::new(TempListener)).await?;
+    Ok(())
+}
+```
+
+## Filters and wildcards
+
+`register_listener` takes a **source filter** and an optional sink filter. A
+filter component may be a wildcard: authority `"*"`, resource id `0xFFFF` (any
+resource), or the entity-instance wildcard. For example:
+
+```rust
+# use up_rust::UUri;
+// Everything entity 0x1_0001 publishes, on any topic.
+let all_topics = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0xFFFF)?;
+
+// One exact topic.
+let one_topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
+# let _ = (all_topics, one_topic);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Exact registrations receive one topic; wildcard registrations fan in. The
+matching rules are the same ones a transport implements. The
+[`UTransport` tutorial](crate::guide::utransport) shows them from the provider
+side.
+
+For which trait is which, see the [trait map](crate::guide::trait_map).

--- a/src/guide/transport.md
+++ b/src/guide/transport.md
@@ -1,66 +1,130 @@
-# The Transport Layer (up-L1)
+# Use the Transport Layer directly
 
-Sometimes you want the floor itself: no role features, no protobuf, no runtime
-beyond your own — just build a [`UMessage`](crate::UMessage) and hand it to the
-[`UTransport`](crate::UTransport) your deployment configured.
+[`UTransport`](crate::UTransport) is the message-level interface shared by
+applications, Communication Layer roles, and transport providers. It supports
+outbound messages plus two delivery modes: registered listeners for push and
+[`UTransport::receive`](crate::UTransport::receive) for pull. A transport
+supports at least one delivery mode and may support both.
 
-## Publish
+## Send a message
 
 ```rust
-use up_rust::{UMessageBuilder, UPayloadFormat, UTransport, UUri};
+use up_rust::{UMessageBuilder, UPayloadFormat, UStatus, UTransport, UUri};
 
-async fn publish(transport: &dyn UTransport) -> Result<(), Box<dyn std::error::Error>> {
-    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
+async fn publish(transport: &dyn UTransport) -> Result<(), UStatus> {
+    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)
+        .expect("valid topic URI");
     let message = UMessageBuilder::publish(topic)
-        .build_with_payload("92.5", UPayloadFormat::Text)?;
-    transport.send(message).await?;
-    Ok(())
+        .build_with_payload("92.5", UPayloadFormat::Text)
+        .expect("valid publish message");
+    transport.send(message).await
 }
 ```
 
-## Receive
+[`UTransport::send`](crate::UTransport::send) returns the result of that
+transport's send operation. Success means that operation reached the checkpoint
+defined by the implementation. For a protocol-backed transport, L1 describes
+this as handing the message to the underlying protocol's send path. It is not a
+portable end-to-end delivery or application-processing acknowledgement. The
+example asserts its fixed URI and message inputs so its result exposes the
+[`UStatus`](crate::UStatus) returned by `send`.
+
+## Receive by push
+
+Push transports deliver each matching message at least once to registered
+[`UListener`](crate::UListener) instances. Registration and unregistration use
+listener identity, so retain the same [`Arc`](std::sync::Arc) for both calls:
 
 ```rust
 use std::sync::Arc;
-use up_rust::{UListener, UMessage, UTransport, UUri};
+use up_rust::{UListener, UMessage, UStatus, UTransport, UUri};
 
 struct TempListener;
 
 #[async_trait::async_trait]
 impl UListener for TempListener {
     async fn on_receive(&self, message: UMessage) {
-        // Prints: engine temp update: Some(b"92.5") for the publish above.
         println!("engine temp update: {:?}", message.payload());
     }
 }
 
-async fn subscribe(transport: &dyn UTransport) -> Result<(), Box<dyn std::error::Error>> {
-    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
-    transport.register_listener(&topic, None, Arc::new(TempListener)).await?;
-    Ok(())
+struct PushRegistration {
+    topic: UUri,
+    listener: Arc<dyn UListener>,
+}
+
+async fn subscribe(transport: &dyn UTransport) -> Result<PushRegistration, UStatus> {
+    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)
+        .expect("valid topic URI");
+    let listener: Arc<dyn UListener> = Arc::new(TempListener);
+
+    transport
+        .register_listener(&topic, None, listener.clone())
+        .await?;
+
+    Ok(PushRegistration { topic, listener })
+}
+
+async fn unsubscribe(
+    transport: &dyn UTransport,
+    registration: PushRegistration,
+) -> Result<(), UStatus> {
+    transport
+        .unregister_listener(&registration.topic, None, registration.listener)
+        .await
 }
 ```
 
-## Filters and wildcards
+[`UTransport::register_listener`](crate::UTransport::register_listener) and
+[`UTransport::unregister_listener`](crate::UTransport::unregister_listener)
+take the source filter, optional sink filter, and listener. Unregistration must
+use the same values that identify the registration, so the returned
+`PushRegistration` retains them until `unsubscribe` consumes it.
 
-`register_listener` takes a **source filter** and an optional sink filter. A
-filter component may be a wildcard: authority `"*"`, resource id `0xFFFF` (any
-resource), or the entity-instance wildcard. For example:
+## Receive by pull
+
+Pull transports return one matching message from
+[`UTransport::receive`](crate::UTransport::receive). The method returns
+[`UCode::NotFound`](crate::UCode::NotFound) when no matching message is
+available. When several messages match, L1 selects the oldest one that has not
+expired:
 
 ```rust
-# use up_rust::UUri;
-// Everything entity 0x1_0001 publishes, on any topic.
-let all_topics = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0xFFFF)?;
+use up_rust::{UMessage, UStatus, UTransport, UUri};
 
-// One exact topic.
-let one_topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
-# let _ = (all_topics, one_topic);
-# Ok::<(), Box<dyn std::error::Error>>(())
+async fn receive_one(transport: &dyn UTransport) -> Result<UMessage, UStatus> {
+    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)
+        .expect("valid topic URI");
+    transport.receive(&topic, None).await
+}
 ```
 
-Exact registrations receive one topic; wildcard registrations fan in. The
-matching rules are the same ones a transport implements. The
-[`UTransport` tutorial](crate::guide::utransport) shows them from the provider
-side.
+## Select messages with filters
 
-For which trait is which, see the [trait map](crate::guide::trait_map).
+Push registration and pull receive both take a source filter and an optional
+sink filter. [`UUri::any`](crate::UUri::any) matches any source,
+[`UUri::any_with_resource_id`](crate::UUri::any_with_resource_id) matches any
+source with one resource ID, and [`UUri::matches`](crate::UUri::matches)
+evaluates a concrete URI against a wildcard filter.
+
+```rust
+use up_rust::UUri;
+
+let any_source = UUri::any();
+let topic_at_any_source = UUri::any_with_resource_id(0x8001);
+let one_topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)
+    .expect("valid topic URI");
+
+assert!(any_source.matches(&one_topic));
+assert!(topic_at_any_source.matches(&one_topic));
+```
+
+Use an exact [`UUri`](crate::UUri) to select one address. Wildcard filters can
+select several sources or resources, subject to the valid source/sink resource
+combinations in the L1 Transport Layer specification.
+
+The [transport implementation guide](crate::guide::utransport) points to the
+authoritative filter rules, delivery semantics, and protocol-binding
+requirements.
+
+See the [trait map](crate::guide::trait_map) for the public API relationships.

--- a/src/guide/utransport.md
+++ b/src/guide/utransport.md
@@ -1,0 +1,197 @@
+# The UTransport family
+
+A transport moves messages over one technology: a broker, a bus, or shared
+memory. Every transport implements the same contract so application code does
+not depend on that technology.
+
+A `UTransport`-family transport implements one trait,
+[`UTransport`](crate::UTransport): deliver a [`UMessage`](crate::UMessage),
+and keep a registry of listeners with their source/sink filters. Here is
+a **complete, working transport** — an in-process loopback — as a
+running example:
+
+```rust
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use up_rust::{
+    verify_filter_criteria, ComparableListener, UCode, UListener, UMessage, UStatus, UTransport,
+    UUri,
+};
+
+struct Registered {
+    source: UUri,
+    sink: Option<UUri>,
+    listener: ComparableListener,
+}
+
+#[derive(Default)]
+struct MiniTransport {
+    listeners: RwLock<Vec<Registered>>,
+}
+
+#[async_trait::async_trait]
+impl UTransport for MiniTransport {
+    async fn send(&self, message: UMessage) -> Result<(), UStatus> {
+        // A real transport hands the bytes to its technology here.
+        // The loopback "technology" is: match filters, dispatch locally.
+        let matching_listeners = {
+            let source = message.attributes().source();
+            let sink = message.attributes().sink();
+            self.listeners
+                .read()
+                .await
+                .iter()
+                .filter(|registered| {
+                    let source_ok = registered.source.matches(source);
+                    let sink_ok = match (&registered.sink, sink) {
+                        (Some(pattern), Some(candidate)) => pattern.matches(candidate),
+                        (None, None) => true,
+                        _ => false,
+                    };
+                    source_ok && sink_ok
+                })
+                .map(|registered| registered.listener.clone())
+                .collect::<Vec<_>>()
+        };
+
+        // Never hold the registry lock while invoking application code.
+        for listener in matching_listeners {
+            listener.on_receive(message.clone()).await;
+        }
+        Ok(())
+    }
+
+    async fn register_listener(
+        &self,
+        source_filter: &UUri,
+        sink_filter: Option<&UUri>,
+        listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus> {
+        // Reject filter combinations the spec forbids before storing anything.
+        verify_filter_criteria(source_filter, sink_filter).map_err(|e| *e)?;
+        let registered = Registered {
+            source: source_filter.to_owned(),
+            sink: sink_filter.map(ToOwned::to_owned),
+            listener: ComparableListener::new(listener),
+        };
+        let mut listeners = self.listeners.write().await;
+        if listeners.iter().any(|existing| {
+            existing.source == registered.source
+                && existing.sink == registered.sink
+                && existing.listener == registered.listener
+        }) {
+            return Err(UStatus::fail_with_code(
+                UCode::AlreadyExists,
+                "listener already registered for filters",
+            ));
+        }
+        listeners.push(registered);
+        Ok(())
+    }
+
+    async fn unregister_listener(
+        &self,
+        source_filter: &UUri,
+        sink_filter: Option<&UUri>,
+        listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus> {
+        let target = ComparableListener::new(listener);
+        let mut listeners = self.listeners.write().await;
+        let before = listeners.len();
+        listeners.retain(|r| {
+            !(r.source == *source_filter
+                && r.sink.as_ref() == sink_filter
+                && r.listener == target)
+        });
+        if listeners.len() < before {
+            Ok(())
+        } else {
+            Err(UStatus::fail_with_code(UCode::NotFound, "no such listener"))
+        }
+    }
+}
+
+// Prove it works: register, send, receive.
+struct Capture(tokio::sync::mpsc::UnboundedSender<UMessage>);
+#[async_trait::async_trait]
+impl UListener for Capture {
+    async fn on_receive(&self, message: UMessage) {
+        let _ = self.0.send(message);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use up_rust::{UMessageBuilder, UPayloadFormat};
+    let transport = MiniTransport::default();
+    let topic = UUri::try_from_parts("demo", 0x1_0001, 1, 0x8001)?;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let listener: Arc<dyn UListener> = Arc::new(Capture(tx));
+    transport.register_listener(&topic, None, listener.clone()).await?;
+    let duplicate = transport.register_listener(&topic, None, listener).await.unwrap_err();
+    assert_eq!(duplicate.get_code(), UCode::AlreadyExists);
+    transport
+        .send(UMessageBuilder::publish(topic).build_with_payload("42", UPayloadFormat::Text)?)
+        .await?;
+
+    let received = rx.recv().await.expect("message delivered");
+    assert_eq!(received.payload().unwrap().as_ref(), b"42");
+    Ok(())
+}
+```
+
+The crate's own [`LocalTransport`](crate::local_transport::LocalTransport)
+is this same shape grown up: a `HashSet` keyed on
+[`ComparableListener`](crate::ComparableListener) so duplicate
+registrations are rejected with `AlreadyExists`, and filter matching via
+the message's attributes. Read its source when you outgrow the sketch.
+
+## Payload and routing integrity
+
+Preserve all three payload states: absent, present with zero bytes, and present
+with nonempty bytes. Payload presence is not inferred from length.
+
+If the underlying protocol or broker mirrors routing fields in native headers,
+validate those fields against the message attributes before invoking a callback
+or forwarding. Route from the validated source and sink, never from payload
+bytes.
+
+## Listener lifecycle and readiness
+
+Getting registration right matters more than it looks: a listener registered
+twice double-delivers, and one dropped early loses messages silently.
+Registration completes only when the binding can state what readiness means for
+its technology. Discovery-backed transports should expose a bounded peer or
+subscription readiness result, not use duplicate application sends as a
+readiness protocol. An absent peer returns a bounded, observable status.
+
+Listener dispatch preserves the binding's documented ordering and is bounded by
+an explicit queue, worker, or backpressure policy. Successful unregister is a
+quiescence boundary: a callback already running may complete if the binding says
+so, but no later callback may begin. Cancellation wakes blocking receive or poll
+operations, shutdown joins workers, and native entities are deleted
+deterministically so a transport can be recreated in the same domain.
+
+Polling is an acceptable native fallback when its wait is wakeable or bounded,
+each iteration bounds take and dispatch work, failures become health or status
+signals, and dropping the transport cannot leave an unjoined worker.
+
+What a real technology changes: `send` maps the message attributes and payload
+to that binding's wire representation and hands it to the broker or bus. The
+receive side runs the inverse mapping and rebuilds a `UMessage` before
+dispatching to listeners.
+
+That is the whole level. Error mapping: use
+[`UCode`](crate::UCode) faithfully — `AlreadyExists` for duplicate
+registration, `NotFound` for unknown listeners, `InvalidArgument` for
+filters your technology cannot express, `Unavailable` when the link is
+down. Applications and the roles built above you switch on these codes.
+
+## Definition of done
+
+"It compiles and my demo works" is not enough for a transport. Its tests should
+cover payload presence, exact and wildcard routing, duplicate registration,
+unregister quiescence, bounded failure, reconnect, and deterministic shutdown.
+
+[the guide hub](crate::guide).

--- a/src/guide/utransport.md
+++ b/src/guide/utransport.md
@@ -25,11 +25,11 @@ selected binding.
 A transport owns two directional paths:
 
 ```text
-outbound: UMessage -> validate -> encode for binding -> native send path
+outbound: validated UMessage -> encode for binding -> native send path
 
-inbound:  native PDU -> decode for binding -> validate UMessage
-                                               |-> matching push listeners
-                                               `-> pull receive queue
+inbound:  native PDU -> decode and validate for binding -> UMessage
+                                                           |-> matching push listeners
+                                                           `-> pull receive queue
 ```
 
 The binding defines the native representation. L1 defines what callers can
@@ -40,27 +40,22 @@ observe at the `UTransport` methods.
 [`UTransport::send`](crate::UTransport::send) takes one complete `UMessage`.
 The implementation should:
 
-1. validate the message attributes;
-2. preserve all attributes and the payload while encoding the selected
+1. preserve all attributes and the payload while encoding the selected
    binding;
-3. perform the protocol-specific send operation; and
-4. convert failures into an appropriate [`UStatus`](crate::UStatus).
+2. perform the protocol-specific send operation; and
+3. convert failures into an appropriate [`UStatus`](crate::UStatus).
 
-The crate exposes the same attribute validators used by its message builders:
+Keep attribute validation at the boundary that constructs a `UMessage`.
+[`UMessageBuilder`](crate::UMessageBuilder) validates attributes before it
+returns a message. Decoders and custom type mappings should likewise reject an
+invalid representation instead of producing an invalid `UMessage`. A transport
+therefore does not normally need to repeat the same validation in `send`.
 
-```rust
-use up_rust::{
-    UAttributesValidator, UAttributesValidators, UCode, UMessage, UStatus,
-};
-
-fn validate_outbound(message: &UMessage) -> Result<(), UStatus> {
-    UAttributesValidators::get_validator_for_attributes(message.attributes())
-        .validate(message.attributes())
-        .map_err(|error| {
-            UStatus::fail_with_code(UCode::InvalidArgument, error.to_string())
-        })
-}
-```
+The pinned L1 specification still requires
+[`UCode::InvalidArgument`](crate::UCode::InvalidArgument) if an invalid message
+does reach `send`. Treat that as a fallback for integrations that do not yet
+enforce validation when constructing a `UMessage`, not as a reason to revalidate
+values from validated constructors.
 
 Successful `send` completion is not a transport-independent delivery receipt.
 For protocol-backed transports, L1 says the message has been handed to the
@@ -151,7 +146,7 @@ These notable L1 outcomes are not an exhaustive list of native failures:
 
 | Method | Required outcome |
 | --- | --- |
-| `send` | `InvalidArgument` for an invalid message; `PermissionDenied` is recommended when unauthorized sending can be determined locally |
+| `send` | `InvalidArgument` if an invalid message reaches the method; `PermissionDenied` is recommended when unauthorized sending can be determined locally |
 | `receive` | `Unimplemented` when pull is unsupported; `NotFound` when no valid matching message is available |
 | `register_listener` | `Unimplemented` when push is unsupported; `InvalidArgument` for invalid filters; `ResourceExhausted` at a configured listener limit; `PermissionDenied` is recommended when unauthorized consumption can be determined locally |
 | `unregister_listener` | `Unimplemented` when push is unsupported; `InvalidArgument` for invalid filters; `NotFound` when the registration does not exist |
@@ -177,7 +172,9 @@ guarantees.
 
 ## Existing implementations
 
-The published
+For a minimal in-process push implementation, see
+[`LocalTransport`](https://docs.rs/up-rust/latest/up_rust/local_transport/struct.LocalTransport.html).
+For protocol-backed designs, the published
 [`up-transport-zenoh`](https://crates.io/crates/up-transport-zenoh),
 [`up-transport-mqtt5`](https://crates.io/crates/up-transport-mqtt5), and
 [`up-transport-vsomeip`](https://crates.io/crates/up-transport-vsomeip) crates

--- a/src/guide/utransport.md
+++ b/src/guide/utransport.md
@@ -1,197 +1,187 @@
-# The UTransport family
+# Implement UTransport
 
-A transport moves messages over one technology: a broker, a bus, or shared
-memory. Every transport implements the same contract so application code does
-not depend on that technology.
+[`UTransport`](crate::UTransport) adapts [`UMessage`](crate::UMessage) values
+and [`UUri`](crate::UUri) filters to a messaging technology. Implement
+[`UTransport::send`](crate::UTransport::send) and at least one receive mode:
+push through listener registration, pull through
+[`UTransport::receive`](crate::UTransport::receive), or both. The default
+receive and listener methods return
+[`UCode::Unimplemented`](crate::UCode::Unimplemented).
 
-A `UTransport`-family transport implements one trait,
-[`UTransport`](crate::UTransport): deliver a [`UMessage`](crate::UMessage),
-and keep a registry of listeners with their source/sink filters. Here is
-a **complete, working transport** — an in-process loopback — as a
-running example:
+## Start with three contracts
+
+| Source | What it defines |
+| --- | --- |
+| [`UTransport`](crate::UTransport) | Rust method signatures and default behavior |
+| [L1 Transport Layer specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/README.adoc) | Observable operation, validation, authorization, delivery, and error requirements |
+| [Zenoh](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/zenoh.adoc), [MQTT 5](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/mqtt_5.adoc), or [SOME/IP](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/someip.adoc) binding | Mapping between uProtocol messages and the selected protocol |
+
+Use all three when implementing and testing a transport. This guide explains
+how they fit together; it does not replace the complete L1 specification or the
+selected binding.
+
+## See the adapter boundary
+
+A transport owns two directional paths:
+
+```text
+outbound: UMessage -> validate -> encode for binding -> native send path
+
+inbound:  native PDU -> decode for binding -> validate UMessage
+                                               |-> matching push listeners
+                                               `-> pull receive queue
+```
+
+The binding defines the native representation. L1 defines what callers can
+observe at the `UTransport` methods.
+
+## Implement outbound send
+
+[`UTransport::send`](crate::UTransport::send) takes one complete `UMessage`.
+The implementation should:
+
+1. validate the message attributes;
+2. preserve all attributes and the payload while encoding the selected
+   binding;
+3. perform the protocol-specific send operation; and
+4. convert failures into an appropriate [`UStatus`](crate::UStatus).
+
+The crate exposes the same attribute validators used by its message builders:
 
 ```rust
-use std::sync::Arc;
-use tokio::sync::RwLock;
 use up_rust::{
-    verify_filter_criteria, ComparableListener, UCode, UListener, UMessage, UStatus, UTransport,
-    UUri,
+    UAttributesValidator, UAttributesValidators, UCode, UMessage, UStatus,
 };
 
-struct Registered {
-    source: UUri,
-    sink: Option<UUri>,
-    listener: ComparableListener,
-}
-
-#[derive(Default)]
-struct MiniTransport {
-    listeners: RwLock<Vec<Registered>>,
-}
-
-#[async_trait::async_trait]
-impl UTransport for MiniTransport {
-    async fn send(&self, message: UMessage) -> Result<(), UStatus> {
-        // A real transport hands the bytes to its technology here.
-        // The loopback "technology" is: match filters, dispatch locally.
-        let matching_listeners = {
-            let source = message.attributes().source();
-            let sink = message.attributes().sink();
-            self.listeners
-                .read()
-                .await
-                .iter()
-                .filter(|registered| {
-                    let source_ok = registered.source.matches(source);
-                    let sink_ok = match (&registered.sink, sink) {
-                        (Some(pattern), Some(candidate)) => pattern.matches(candidate),
-                        (None, None) => true,
-                        _ => false,
-                    };
-                    source_ok && sink_ok
-                })
-                .map(|registered| registered.listener.clone())
-                .collect::<Vec<_>>()
-        };
-
-        // Never hold the registry lock while invoking application code.
-        for listener in matching_listeners {
-            listener.on_receive(message.clone()).await;
-        }
-        Ok(())
-    }
-
-    async fn register_listener(
-        &self,
-        source_filter: &UUri,
-        sink_filter: Option<&UUri>,
-        listener: Arc<dyn UListener>,
-    ) -> Result<(), UStatus> {
-        // Reject filter combinations the spec forbids before storing anything.
-        verify_filter_criteria(source_filter, sink_filter).map_err(|e| *e)?;
-        let registered = Registered {
-            source: source_filter.to_owned(),
-            sink: sink_filter.map(ToOwned::to_owned),
-            listener: ComparableListener::new(listener),
-        };
-        let mut listeners = self.listeners.write().await;
-        if listeners.iter().any(|existing| {
-            existing.source == registered.source
-                && existing.sink == registered.sink
-                && existing.listener == registered.listener
-        }) {
-            return Err(UStatus::fail_with_code(
-                UCode::AlreadyExists,
-                "listener already registered for filters",
-            ));
-        }
-        listeners.push(registered);
-        Ok(())
-    }
-
-    async fn unregister_listener(
-        &self,
-        source_filter: &UUri,
-        sink_filter: Option<&UUri>,
-        listener: Arc<dyn UListener>,
-    ) -> Result<(), UStatus> {
-        let target = ComparableListener::new(listener);
-        let mut listeners = self.listeners.write().await;
-        let before = listeners.len();
-        listeners.retain(|r| {
-            !(r.source == *source_filter
-                && r.sink.as_ref() == sink_filter
-                && r.listener == target)
-        });
-        if listeners.len() < before {
-            Ok(())
-        } else {
-            Err(UStatus::fail_with_code(UCode::NotFound, "no such listener"))
-        }
-    }
-}
-
-// Prove it works: register, send, receive.
-struct Capture(tokio::sync::mpsc::UnboundedSender<UMessage>);
-#[async_trait::async_trait]
-impl UListener for Capture {
-    async fn on_receive(&self, message: UMessage) {
-        let _ = self.0.send(message);
-    }
-}
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use up_rust::{UMessageBuilder, UPayloadFormat};
-    let transport = MiniTransport::default();
-    let topic = UUri::try_from_parts("demo", 0x1_0001, 1, 0x8001)?;
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-
-    let listener: Arc<dyn UListener> = Arc::new(Capture(tx));
-    transport.register_listener(&topic, None, listener.clone()).await?;
-    let duplicate = transport.register_listener(&topic, None, listener).await.unwrap_err();
-    assert_eq!(duplicate.get_code(), UCode::AlreadyExists);
-    transport
-        .send(UMessageBuilder::publish(topic).build_with_payload("42", UPayloadFormat::Text)?)
-        .await?;
-
-    let received = rx.recv().await.expect("message delivered");
-    assert_eq!(received.payload().unwrap().as_ref(), b"42");
-    Ok(())
+fn validate_outbound(message: &UMessage) -> Result<(), UStatus> {
+    UAttributesValidators::get_validator_for_attributes(message.attributes())
+        .validate(message.attributes())
+        .map_err(|error| {
+            UStatus::fail_with_code(UCode::InvalidArgument, error.to_string())
+        })
 }
 ```
 
-The crate's own [`LocalTransport`](crate::local_transport::LocalTransport)
-is this same shape grown up: a `HashSet` keyed on
-[`ComparableListener`](crate::ComparableListener) so duplicate
-registrations are rejected with `AlreadyExists`, and filter matching via
-the message's attributes. Read its source when you outgrow the sketch.
+Successful `send` completion is not a transport-independent delivery receipt.
+For protocol-backed transports, L1 says the message has been handed to the
+underlying protocol's send path, but the observable checkpoint depends on the
+implementation and protocol. For example, one transport might wait for a broker
+acknowledgement while an in-process transport might complete after local
+dispatch. Document that checkpoint without claiming that a recipient received
+or processed the message.
 
-## Payload and routing integrity
+## Build one inbound path
 
-Preserve all three payload states: absent, present with zero bytes, and present
-with nonempty bytes. Payload presence is not inferred from length.
+Decode each native protocol data unit according to the selected binding, rebuild
+the `UMessage`, and validate its attributes before exposing it through push or
+pull. Preserve the message metadata and payload during decoding.
 
-If the underlying protocol or broker mirrors routing fields in native headers,
-validate those fields against the message attributes before invoking a callback
-or forwarding. Route from the validated source and sink, never from payload
-bytes.
+For push, L1 requires invalid inbound data to be discarded. For pull, an
+inbound protocol data unit that cannot produce a valid matching `UMessage` is
+reported as [`UCode::NotFound`](crate::UCode::NotFound). Keep decoding and
+validation shared so both receive modes interpret the binding consistently.
 
-## Listener lifecycle and readiness
+## Implement push delivery
 
-Getting registration right matters more than it looks: a listener registered
-twice double-delivers, and one dropped early loses messages silently.
-Registration completes only when the binding can state what readiness means for
-its technology. Discovery-backed transports should expose a bounded peer or
-subscription readiness result, not use duplicate application sends as a
-readiness protocol. An absent peer returns a bounded, observable status.
+Push delivery uses
+[`UTransport::register_listener`](crate::UTransport::register_listener) and
+[`UTransport::unregister_listener`](crate::UTransport::unregister_listener).
+Both methods identify a registration with the source filter, optional sink
+filter, and listener identity:
 
-Listener dispatch preserves the binding's documented ordering and is bounded by
-an explicit queue, worker, or backpressure policy. Successful unregister is a
-quiescence boundary: a callback already running may complete if the binding says
-so, but no later callback may begin. Cancellation wakes blocking receive or poll
-operations, shutdown joins workers, and native entities are deleted
-deterministically so a transport can be recreated in the same domain.
+```rust
+use std::sync::Arc;
+use up_rust::{UListener, UUri};
 
-Polling is an acceptable native fallback when its wait is wakeable or bounded,
-each iteration bounds take and dispatch work, failures become health or status
-signals, and dropping the transport cannot leave an unjoined worker.
+struct Registration {
+    source_filter: UUri,
+    sink_filter: Option<UUri>,
+    listener: Arc<dyn UListener>,
+}
+```
 
-What a real technology changes: `send` maps the message attributes and payload
-to that binding's wire representation and hands it to the broker or bus. The
-receive side runs the inverse mapping and rebuilds a `UMessage` before
-dispatching to listeners.
+Validate a filter pair before changing registration state. The SDK helper
+implements the shared resource-ID checks from L1:
 
-That is the whole level. Error mapping: use
-[`UCode`](crate::UCode) faithfully — `AlreadyExists` for duplicate
-registration, `NotFound` for unknown listeners, `InvalidArgument` for
-filters your technology cannot express, `Unavailable` when the link is
-down. Applications and the roles built above you switch on these codes.
+```rust
+use up_rust::{verify_filter_criteria, UStatus, UUri};
 
-## Definition of done
+fn validate_filters(
+    source_filter: &UUri,
+    sink_filter: Option<&UUri>,
+) -> Result<(), UStatus> {
+    verify_filter_criteria(source_filter, sink_filter)
+        .map_err(|status| *status)
+}
+```
 
-"It compiles and my demo works" is not enough for a transport. Its tests should
-cover payload presence, exact and wildcard routing, duplicate registration,
-unregister quiescence, bounded failure, reconnect, and deterministic shutdown.
+A push implementation must make these lifecycle points observable:
 
-[the guide hub](crate::guide).
+* Repeating registration with the same filters and listener has the same effect
+  as registering once.
+* Registration does not succeed until messages received afterward can reach the
+  listener.
+* Every valid matching message received after successful registration invokes
+  each matching listener at least once.
+* Successful unregistration is a barrier: the removed registration receives no
+  later messages.
+* Configured total and per-filter listener limits fail registration with
+  [`UCode::ResourceExhausted`](crate::UCode::ResourceExhausted).
+
+Use listener identity, not merely its concrete type, when comparing
+registrations. [`ComparableListener`](crate::ComparableListener) is available
+to implementations that need hashable and comparable `Arc<dyn UListener>`
+values.
+
+## Implement pull delivery
+
+[`UTransport::receive`](crate::UTransport::receive) selects by the same source
+and optional sink filter shape used for push. If multiple unexpired messages
+match, return the oldest one. Return
+[`UCode::NotFound`](crate::UCode::NotFound) when no valid matching message is
+available, and [`UCode::Unimplemented`](crate::UCode::Unimplemented) when the
+transport does not support pull.
+
+The implementation decides how to buffer native messages, but it must preserve
+the L1 selection and expiry behavior at the method boundary.
+
+## Map errors by operation
+
+These notable L1 outcomes are not an exhaustive list of native failures:
+
+| Method | Required outcome |
+| --- | --- |
+| `send` | `InvalidArgument` for an invalid message; `PermissionDenied` is recommended when unauthorized sending can be determined locally |
+| `receive` | `Unimplemented` when pull is unsupported; `NotFound` when no valid matching message is available |
+| `register_listener` | `Unimplemented` when push is unsupported; `InvalidArgument` for invalid filters; `ResourceExhausted` at a configured listener limit; `PermissionDenied` is recommended when unauthorized consumption can be determined locally |
+| `unregister_listener` | `Unimplemented` when push is unsupported; `InvalidArgument` for invalid filters; `NotFound` when the registration does not exist |
+
+Map other native failures to the closest `UCode`, retain useful diagnostic
+detail in `UStatus`, and document any transport-specific outcomes.
+
+## Document transport-specific behavior
+
+L1 and the selected binding remain the conformance authority. A concrete
+transport should additionally document behavior that its technology determines:
+
+* **send completion:** which native event allows `send` to return success;
+* **reconnect:** whether registrations and buffered messages survive a lost
+  connection;
+* **ordering:** which messages, if any, are observed in a stable order;
+* **backpressure:** whether senders wait, fail, or drop when capacity is
+  exhausted; and
+* **shutdown:** how pending sends, receives, and listener callbacks finish.
+
+Do not turn those transport-specific choices into general `UTransport`
+guarantees.
+
+## Existing implementations
+
+The published
+[`up-transport-zenoh`](https://crates.io/crates/up-transport-zenoh),
+[`up-transport-mqtt5`](https://crates.io/crates/up-transport-mqtt5), and
+[`up-transport-vsomeip`](https://crates.io/crates/up-transport-vsomeip) crates
+show how concrete technologies implement the interface. Use them as design
+references; use L1 and the selected binding as the conformance authority.
+
+Return to the [guide](crate::guide).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,87 +12,67 @@
  ********************************************************************************/
 
 /*!
-up-rust is the Rust language library for
-[Eclipse uProtocol&trade;](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/README.adoc) —
-a protocol that lets software components (in vehicles and beyond) publish data,
-subscribe to it, and call each other's services over whatever messaging
-technology a deployment happens to use: MQTT, Zenoh, DDS, shared memory, and
-more.
+# uProtocol in Rust
 
-The idea in one sentence: **you write against one small messaging API, and the
-technology underneath stays swappable.**
+uProtocol separates application messaging from the transport used to carry
+messages across an IPC or network boundary. Applications can use five
+**Communication Layer** role APIs across four messaging patterns:
 
-## Your first message
+* `Publisher` emits events;
+* `Subscriber` consumes events;
+* `Notifier` targets a one-way message;
+* `RpcClient` invokes a service, while `RpcServer` serves it.
+
+Each role is an API over a [`UTransport`]. Applications can instead call
+[`UTransport::send`] directly and receive messages through registered
+listeners for push, [`UTransport::receive`] for pull, or both. A transport maps
+the contract to its broker, bus, or peer-to-peer protocol.
 
 ```rust
-use up_rust::{UMessageBuilder, UPayloadFormat, UTransport, UUri};
+use up_rust::{UMessageBuilder, UPayloadFormat, UStatus, UTransport, UUri};
 
 async fn publish_engine_temp(
     transport: &dyn UTransport,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Every message has a source address: authority / entity / version / resource.
-    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
-
+) -> Result<(), UStatus> {
+    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)
+        .expect("valid topic URI");
     let message = UMessageBuilder::publish(topic)
-        .build_with_payload("92.5", UPayloadFormat::Text)?;
+        .build_with_payload("92.5", UPayloadFormat::Text)
+        .expect("valid publish message");
 
-    transport.send(message).await?;
-    Ok(())
+    transport.send(message).await
 }
 ```
 
-That is the whole application-side model: build a [`UMessage`], hand it to a
-[`UTransport`] someone has configured, done. Receiving is the mirror image —
-register a [`UListener`] for the addresses you care about.
+The [`guide`] provides:
 
-## Which reader are you?
-
-| You want to... | Start at | Cargo features |
-| --- | --- | --- |
-| Write an application using publish, subscribe, notifications, or RPC | The role traits in [`communication`], then the [Communication Layer guide](crate::guide::applications::communication) | `communication`, `util` |
-| Build and receive messages directly with the smallest API surface | The [Transport Layer application guide](crate::guide::applications::transport) | none |
-| Connect a messaging technology to uProtocol | [`UTransport`], then the [transport implementation guide](crate::guide::utransport) | `util` for the runnable guide |
-
-The [`guide`] walks each path end to end with code.
-
-## Three terms you'll meet everywhere
-
-* **uEntity** — any software component that talks uProtocol (an app, a service,
-  or a sensor feed).
-* **Transport Layer (up-L1)** — the layer that moves messages; a *transport* is
-  one implementation of it (Zenoh, MQTT, DDS, and so on).
-* **Communication Layer (up-L2)** — the application-facing publish, subscribe,
-  notification, and RPC roles built on top of any transport.
-
-## Module map
-
-* [`communication`] contains the up-L2 roles most applications use.
-* [`UMessage`], [`UUri`], and [`UAttributes`] form the core message model.
-* [`UTransport`] is the up-L1 contract implemented by transport providers.
-* [`guide`] contains the audience-oriented tutorials above.
+* [application role examples](crate::guide::applications::communication),
+* [direct Transport Layer examples](crate::guide::applications::transport),
+* [transport implementation guidance](crate::guide::utransport), and
+* [a public trait map](crate::guide::trait_map).
 
 ## Features
 
 None of the following features are enabled by default, so you can pick and choose which parts of the library you want to use by enabling the corresponding features. Note that some features depend on each other, so enabling one feature might automatically enable other features as well. For example, enabling `up-core-types` will also enable `protobuf-support` since the generated types require that.
 
-* `cloudevents` Enables support for mapping [crate::UMessage]s to/from [crate::CloudEvent]s using Protobuf Format according to the
+* `cloudevents` Enables support for mapping [crate::UMessage]s to/from `CloudEvent`s using Protobuf Format according to the
   [uProtocol specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/cloudevents.adoc).
 * `communication` Enables default implementations for all [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l2/api.adoc) traits on top of the [Transport & Session Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/README.adoc).
-* `protobuf-support` Enables convenience functions on the Transport & Session as well as the Communcation Layer APIs for implicitly mapping objects to protobuf payloads on the fly. This is particularly useful for using protoc-generated types as payloads using the [message builder](crate::UMessageBuilder::build_with_protobuf_payload) or [payload constructor](crate::communication::UPayload::try_from_protobuf). The only requirement for the object types is that they implement the [crate::ProtobufMappable] trait. A blanket implementation for types generated by the `protobuf` crate is also provided. Note that it is still possible to use protobufs as payloads even without enabling this feature. The payload of a [crate::UMessage] can be set to an arbitrary byte array, so protobuf messages can be serialized to bytes and set as payload without any support from the library. Enabling this feature just adds some convenient helper functions for automatically handling the mapping to protobuf payloads. The examples also illustrate the usage of these helper functions.
-* `symphony` Enables support for implementing an [Eclipse Symphony](https://github.com/eclipse-symphony) Target Provider as a uService exposed via the Communication Layer API's [RPC Server](crate::communication::RpcServer).
+* `protobuf-support` Enables convenience functions on the Transport & Session as well as the Communication Layer APIs for implicitly mapping objects to protobuf payloads on the fly. This is particularly useful for using protoc-generated types as payloads using `UMessageBuilder::build_with_protobuf_payload` or `UPayload::try_from_protobuf`. The only requirement for the object types is that they implement `ProtobufMappable`. A blanket implementation for types generated by the `protobuf` crate is also provided. Note that it is still possible to use protobufs as payloads even without enabling this feature. The payload of a [crate::UMessage] can be set to an arbitrary byte array, so protobuf messages can be serialized to bytes and set as payload without any support from the library. Enabling this feature just adds some convenient helper functions for automatically handling the mapping to protobuf payloads. The examples also illustrate the usage of these helper functions.
+* `symphony` Enables support for implementing an [Eclipse Symphony](https://github.com/eclipse-symphony) Target Provider as a uService exposed via the Communication Layer API's `RpcServer`.
 * `test-util` provides some useful mock implementations for testing. In particular, provides mock implementations of [UTransport] and Communication Layer API traits which make implementing unit tests a lot easier.
-* `up-core-types` Enables support for mapping the crate's public API types to protobufs as defined in the uProtocol specification. This includes, for example, the `UStatus` type which is used in the Communication Layer API for conveying errors. Enabling this feature also enables `protobuf-support` since the generated types require that.
-* `up-l2-api` Enables support for the [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l2/api.adoc). This includes the trait definitions for the various roles defined by the API, such as [Notifier](crate::communication::Notifier), [Publisher](crate::communication::Publisher), [Subscriber](crate::communication::Subscriber), [RpcClient](crate::communication::RpcClient) and [RpcServer](crate::communication::RpcServer).
-* `up-l2-notifier` Enables a default implementation of the [Notifier](crate::communication::Notifier) trait on top of the Transport Layer API.
-* `up-l2-publisher` Enables a default implementation of the [Publisher](crate::communication::Publisher) trait on top of the Transport Layer API.
-* `up-l2-subscriber` Enables a default implementation of the [Subscriber](crate::communication::Subscriber) trait on top of the Transport Layer API.
-* `up-l2-rpc-client` Enables a default implementation of the [RpcClient](crate::communication::RpcClient) trait on top of the Transport Layer API.
-* `up-l2-rpc-server` Enables a default implementation of the [RpcServer](crate::communication::RpcServer) trait on top of the Transport Layer API.
+* `up-core-types` Enables support for mapping the crate's public API types to protobufs as defined in the uProtocol specification. This includes, for example, the [`UStatus`] type which is used in the Communication Layer API for conveying errors. Enabling this feature also enables `protobuf-support` since the generated types require that.
+* `up-l2-api` Enables support for the [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l2/api.adoc). This includes the trait definitions for the various roles defined by the API, such as `Notifier`, `Publisher`, `Subscriber`, `RpcClient`, and `RpcServer`.
+* `up-l2-notifier` Enables a default implementation of the `Notifier` trait on top of the Transport Layer API.
+* `up-l2-publisher` Enables a default implementation of the `Publisher` trait on top of the Transport Layer API.
+* `up-l2-subscriber` Enables a default implementation of the `Subscriber` trait on top of the Transport Layer API.
+* `up-l2-rpc-client` Enables a default implementation of the `RpcClient` trait on top of the Transport Layer API.
+* `up-l2-rpc-server` Enables a default implementation of the `RpcServer` trait on top of the Transport Layer API.
 * `udiscovery` Enables support for types required to interact with [uDiscovery service](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l3/udiscovery/v3/README.adoc)
   implementations.
 * `usubscription` Enables support for types required to interact with [uSubscription service](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l3/usubscription/v3/README.adoc)
   implementations.
-* `util` provides some useful helper structs. In particular, provides a [local, in-memory UTransport](crate::local_transport::LocalTransport) for exchanging messages within a single process. This transport is also used by the examples illustrating usage of the Communication Layer API.
+* `util` provides some useful helper structs. In particular, it provides the local, in-memory `LocalTransport` for exchanging messages within a single process. This transport is also used by the examples illustrating usage of the Communication Layer API.
 
 ## References
 
@@ -115,8 +95,7 @@ pub mod core;
 #[cfg(feature = "util")]
 pub mod local_transport;
 
-/// A guided tour of the crate: start here if the reference docs feel
-/// like a parts list. Chapter by chapter, with runnable examples.
+/// Audience-oriented examples and implementation guidance.
 pub mod guide {
     #![doc = include_str!("guide/README.md")]
 
@@ -143,14 +122,17 @@ pub mod guide {
         pub mod transport {}
     }
 
-    #[cfg_attr(feature = "util", doc = include_str!("guide/utransport.md"))]
-    #[cfg_attr(
-        not(feature = "util"),
-        doc = "Enable `util` for the runnable transport implementation guide."
-    )]
+    #[doc = include_str!("guide/utransport.md")]
     pub mod utransport {}
 
-    #[doc = include_str!("guide/trait_map.md")]
+    #[cfg_attr(
+        feature = "communication",
+        doc = include_str!("guide/trait_map.md")
+    )]
+    #[cfg_attr(
+        not(feature = "communication"),
+        doc = include_str!("guide/trait_map_core.md")
+    )]
     pub mod trait_map {}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,64 @@
  ********************************************************************************/
 
 /*!
-up-rust is the [Eclipse uProtocol&trade; Language Library](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/languages.adoc) for the
-Rust programming language.
+up-rust is the Rust language library for
+[Eclipse uProtocol&trade;](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/README.adoc) —
+a protocol that lets software components (in vehicles and beyond) publish data,
+subscribe to it, and call each other's services over whatever messaging
+technology a deployment happens to use: MQTT, Zenoh, DDS, shared memory, and
+more.
 
-This crate can be used to
+The idea in one sentence: **you write against one small messaging API, and the
+technology underneath stays swappable.**
 
-* implement uEntities that communicate with each other using the uProtocol [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l2/api.adoc)
-  over one of the supported transport protocols.
-* implement support for an additional transport protocol by means of implementing the [Transport & Session Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/README.adoc).
+## Your first message
+
+```rust
+use up_rust::{UMessageBuilder, UPayloadFormat, UTransport, UUri};
+
+async fn publish_engine_temp(
+    transport: &dyn UTransport,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Every message has a source address: authority / entity / version / resource.
+    let topic = UUri::try_from_parts("my-vehicle", 0x1_0001, 1, 0x8001)?;
+
+    let message = UMessageBuilder::publish(topic)
+        .build_with_payload("92.5", UPayloadFormat::Text)?;
+
+    transport.send(message).await?;
+    Ok(())
+}
+```
+
+That is the whole application-side model: build a [`UMessage`], hand it to a
+[`UTransport`] someone has configured, done. Receiving is the mirror image —
+register a [`UListener`] for the addresses you care about.
+
+## Which reader are you?
+
+| You want to... | Start at | Cargo features |
+| --- | --- | --- |
+| Write an application using publish, subscribe, notifications, or RPC | The role traits in [`communication`], then the [Communication Layer guide](crate::guide::applications::communication) | `communication`, `util` |
+| Build and receive messages directly with the smallest API surface | The [Transport Layer application guide](crate::guide::applications::transport) | none |
+| Connect a messaging technology to uProtocol | [`UTransport`], then the [transport implementation guide](crate::guide::utransport) | `util` for the runnable guide |
+
+The [`guide`] walks each path end to end with code.
+
+## Three terms you'll meet everywhere
+
+* **uEntity** — any software component that talks uProtocol (an app, a service,
+  or a sensor feed).
+* **Transport Layer (up-L1)** — the layer that moves messages; a *transport* is
+  one implementation of it (Zenoh, MQTT, DDS, and so on).
+* **Communication Layer (up-L2)** — the application-facing publish, subscribe,
+  notification, and RPC roles built on top of any transport.
+
+## Module map
+
+* [`communication`] contains the up-L2 roles most applications use.
+* [`UMessage`], [`UUri`], and [`UAttributes`] form the core message model.
+* [`UTransport`] is the up-L1 contract implemented by transport providers.
+* [`guide`] contains the audience-oriented tutorials above.
 
 ## Features
 
@@ -64,6 +114,45 @@ pub mod core;
 
 #[cfg(feature = "util")]
 pub mod local_transport;
+
+/// A guided tour of the crate: start here if the reference docs feel
+/// like a parts list. Chapter by chapter, with runnable examples.
+pub mod guide {
+    #![doc = include_str!("guide/README.md")]
+
+    #[cfg_attr(
+        all(feature = "communication", feature = "util"),
+        doc = include_str!("guide/applications.md")
+    )]
+    #[cfg_attr(
+        not(all(feature = "communication", feature = "util")),
+        doc = "Enable `communication` and `util` for the runnable application guide."
+    )]
+    pub mod applications {
+        #[cfg_attr(
+            all(feature = "communication", feature = "util"),
+            doc = include_str!("guide/communication.md")
+        )]
+        #[cfg_attr(
+            not(all(feature = "communication", feature = "util")),
+            doc = "Enable `communication` and `util` for the runnable Communication Layer guide."
+        )]
+        pub mod communication {}
+
+        #[doc = include_str!("guide/transport.md")]
+        pub mod transport {}
+    }
+
+    #[cfg_attr(feature = "util", doc = include_str!("guide/utransport.md"))]
+    #[cfg_attr(
+        not(feature = "util"),
+        doc = "Enable `util` for the runnable transport implementation guide."
+    )]
+    pub mod utransport {}
+
+    #[doc = include_str!("guide/trait_map.md")]
+    pub mod trait_map {}
+}
 
 #[cfg(feature = "symphony")]
 pub mod symphony;

--- a/src/local_transport.rs
+++ b/src/local_transport.rs
@@ -19,7 +19,9 @@ use std::{collections::HashSet, sync::Arc};
 
 use tokio::sync::RwLock;
 
-use crate::{ComparableListener, UListener, UMessage, UStatus, UTransport, UUri};
+use crate::{
+    verify_filter_criteria, ComparableListener, UListener, UMessage, UStatus, UTransport, UUri,
+};
 
 #[derive(Eq, PartialEq, Hash)]
 struct RegisteredListener {
@@ -81,21 +83,15 @@ impl UTransport for LocalTransport {
         sink_filter: Option<&UUri>,
         listener: Arc<dyn UListener>,
     ) -> Result<(), UStatus> {
+        verify_filter_criteria(source_filter, sink_filter).map_err(|status| *status)?;
         let registered_listener = RegisteredListener {
             source_filter: source_filter.to_owned(),
             sink_filter: sink_filter.map(|u| u.to_owned()),
             listener: ComparableListener::new(listener),
         };
         let mut listeners = self.listeners.write().await;
-        if listeners.contains(&registered_listener) {
-            Err(UStatus::fail_with_code(
-                crate::UCode::AlreadyExists,
-                "listener already registered for filters",
-            ))
-        } else {
-            listeners.insert(registered_listener);
-            Ok(())
-        }
+        listeners.insert(registered_listener);
+        Ok(())
     }
 
     async fn unregister_listener(
@@ -104,6 +100,7 @@ impl UTransport for LocalTransport {
         sink_filter: Option<&UUri>,
         listener: Arc<dyn UListener>,
     ) -> Result<(), UStatus> {
+        verify_filter_criteria(source_filter, sink_filter).map_err(|status| *status)?;
         let registered_listener = RegisteredListener {
             source_filter: source_filter.to_owned(),
             sink_filter: sink_filter.map(|u| u.to_owned()),
@@ -124,7 +121,9 @@ impl UTransport for LocalTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{utransport::MockUListener, LocalUriProvider, StaticUriProvider, UMessageBuilder};
+    use crate::{
+        utransport::MockUListener, LocalUriProvider, StaticUriProvider, UCode, UMessageBuilder,
+    };
 
     #[tokio::test]
     async fn test_send_dispatches_to_matching_listener() {
@@ -210,5 +209,67 @@ mod tests {
                     .unwrap(),
             )
             .await;
+    }
+
+    #[tokio::test]
+    async fn test_register_listener_is_idempotent() {
+        const RESOURCE_ID: u16 = 0xa1b3;
+        let mut listener = MockUListener::new();
+        listener.expect_on_receive().once().return_const(());
+        let listener_ref = Arc::new(listener);
+        let uri_provider = StaticUriProvider::new("my-vehicle", 0x100d, 0x02)
+            .expect("failed to create URI provider");
+        let topic = uri_provider.get_resource_uri(RESOURCE_ID);
+        let transport = LocalTransport::default();
+
+        transport
+            .register_listener(&topic, None, listener_ref.clone())
+            .await
+            .unwrap();
+        transport
+            .register_listener(&topic, None, listener_ref.clone())
+            .await
+            .unwrap();
+
+        transport
+            .send(UMessageBuilder::publish(topic.clone()).build().unwrap())
+            .await
+            .unwrap();
+        transport
+            .unregister_listener(&topic, None, listener_ref)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_register_listener_rejects_invalid_filters() {
+        let listener = Arc::new(MockUListener::new());
+        let uri_provider = StaticUriProvider::new("my-vehicle", 0x100d, 0x02)
+            .expect("failed to create URI provider");
+        let invalid_source_filter = uri_provider.get_resource_uri(0x0001);
+        let transport = LocalTransport::default();
+
+        let error = transport
+            .register_listener(&invalid_source_filter, None, listener)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.get_code(), UCode::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_unregister_listener_rejects_invalid_filters() {
+        let listener = Arc::new(MockUListener::new());
+        let uri_provider = StaticUriProvider::new("my-vehicle", 0x100d, 0x02)
+            .expect("failed to create URI provider");
+        let invalid_source_filter = uri_provider.get_resource_uri(0x0001);
+        let transport = LocalTransport::default();
+
+        let error = transport
+            .unregister_listener(&invalid_source_filter, None, listener)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.get_code(), UCode::InvalidArgument);
     }
 }


### PR DESCRIPTION
This adds a runnable tour of the current up-rust API, whether you're building an application or implementing a transport. It covers the communication roles, direct `UTransport` use, and a complete in-process transport example.
